### PR TITLE
Hotfix release

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -207,7 +207,7 @@ CELERY_BROKER_URL = env("CELERY_BROKER_URL", default=REDIS_URL)
 # Configs
 CARE_API = env("CARE_API")
 CARE_API_TIMEOUT = env.int("CARE_API_TIMEOUT", default=25)
-GATEWAY_DEVICE_ID = env("GATEWAY_DEVICE_ID")
+GATEWAY_DEVICE_ID = env("GATEWAY_DEVICE_ID", default="")
 
 JWKS = JsonWebKey.import_key_set(
     json.loads(base64.b64decode(env("JWKS_BASE64", default=generate_encoded_jwks())))
@@ -222,6 +222,7 @@ CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS")
 
 # Observations
 REDIS_OBSERVATIONS_KEY = "observations"
+AUTOMATED_OBSERVATIONS_ENABLED = env.bool("AUTOMATED_OBSERVATIONS_ENABLED", default=bool(GATEWAY_DEVICE_ID))
 AUTOMATED_OBSERVATIONS_INTERVAL = env.int("AUTOMATED_OBSERVATIONS_INTERVAL", default=60)
 
 

--- a/middleware/tasks/__init__.py
+++ b/middleware/tasks/__init__.py
@@ -10,11 +10,12 @@ from middleware.tasks.store_camera_statuses import store_camera_statuses
 @current_app.on_after_finalize.connect
 def setup_periodic_tasks(sender, **kwargs):
     # Run automated observations every hour
-    sender.add_periodic_task(
-        settings.AUTOMATED_OBSERVATIONS_INTERVAL * 60,
-        automated_observations.s(),
-        name="run-automated-observations",
-    )
+    if settings.AUTOMATED_OBSERVATIONS_ENABLED:
+        sender.add_periodic_task(
+            settings.AUTOMATED_OBSERVATIONS_INTERVAL * 60,
+            automated_observations.s(),
+            name="run-automated-observations",
+        )
 
     # Run observations_s3_dump every 30 seconds
     sender.add_periodic_task(


### PR DESCRIPTION
This pull request introduces configuration changes to enable or disable automated observations based on the presence of a gateway device ID, and updates the periodic task setup logic accordingly. The changes improve the flexibility and reliability of the automated observations feature.

Configuration improvements:

* Added a default value of an empty string for `GATEWAY_DEVICE_ID` in `core/settings.py` to prevent errors when the environment variable is missing.
* Introduced the `AUTOMATED_OBSERVATIONS_ENABLED` flag, which is set to `True` only if a gateway device ID is present, allowing conditional activation of automated observations.

Task scheduling logic:

* Updated the periodic task setup in `middleware/tasks/__init__.py` to schedule automated observations only when `AUTOMATED_OBSERVATIONS_ENABLED` is `True`.